### PR TITLE
[visualbasic/de-de] use compact link with label

### DIFF
--- a/de-de/visualbasic-de.html.markdown
+++ b/de-de/visualbasic-de.html.markdown
@@ -280,8 +280,11 @@ End Module
 
 ## Referenzen
 
-Für diejenigen, die mehr wissen wollen, hat Brian Martin ein umfassenderes <a href="http://www.vbbootcamp.co.uk/" Title="Visual Basic Tutorial">Visual Basic Tutorial</a> erstellt.
+Für diejenigen, die mehr wissen wollen, hat Brian Martin ein umfassenderes
+[Visual Basic Tutorial](http://www.vbbootcamp.co.uk/ "Visual Basic Tutorial")
+erstellt.
 
 Die gesamte Syntax sollte gültig sein.
-Kopieren Sie den Code und fügen Sie ihn in den Visual Basic Compiler ein und führen Sie das Programm aus (F5).
+Kopieren Sie den Code und fügen Sie ihn in den Visual Basic Compiler ein und
+führen Sie das Programm aus (F5).
 


### PR DESCRIPTION
Markdown allows a shorter definition of a link with a label eventually displayed e.g., after the conversion by pandoc to yield a html file.  The equivalence in the result was checked with pandoc  (3.1.9) by

pandoc -s -i visualbasic-de.html.markdown -o test.html

subsequently displayed by firefox (version 115.6.0 esr).

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
